### PR TITLE
Deploy glossary assets to gh-pages branch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,26 +3,15 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - hugo
+      - master
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
-
-      # - name: Checkout python
-      #   uses: actions/checkout@v2
-      # # Setup steps
-      # - uses: actions/setup-python@v2
-      #   with:
-      #     python-version: "3.9.11"
-
-#         # hack to have lower-case links instead e.g. instead of term/Apache-Avro we have term/apache-avro
-#       - name: Convert links of terms to lower case
-#         run: python3 lower_case.py
 
       - name: Build Link Index
         uses: jackyzha0/hugo-obsidian@v2.18
@@ -32,28 +21,19 @@ jobs:
           output: assets/indices
           root: .
 
-      # - name: Convert linkIndex to lower case (assets)
-      #   run: sudo python3 lower_link_index.py "assets/indices/"
-
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.96.0'
+          hugo-version: 'latest'
           extended: true
 
       - name: Build Hugo 
         run: hugo --minify
 
-         # # hack to also update graph view to lower-case (otherwise links are not showing correctly)
-      # - name: Convert links to lower case (public)
-        # run: sudo python3 lower_link_index.py "public/indices/"
-
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }} 
-          personal_token: ${{ secrets.PERSONAL_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
-          external_repository: airbyteglossary/airbyteglossary.github.io 
-          publish_branch: master  # deploying branch
-          cname: glossary.airbyte.com # without trailing slash #https://airbytehq.github.io/brain
+          publish_branch: gh-pages
+          cname: glossary.airbyte.com

--- a/deployment.md
+++ b/deployment.md
@@ -1,7 +1,9 @@
 # Deployment Details
-There are two GitHub Actions. First [Deploy to GitHub Pages](https://github.com/airbytehq/glossary/actions/workflows/deploy.yaml) that package branch `hugo` and run the deployment (e.g. running GoHugo), essentially rendering the webpage to a static webpage. It will build and publish the static website to [master](https://github.com/airbyteglossary/airbyteglossary.github.io/tree/master) branch on the publishing repo.
+There are two GitHub Actions:
+- [Deploy to GitHub Pages](https://github.com/airbytehq/glossary/actions/workflows/deploy.yaml) - this action packages `master` branch and runs the deployment (e.g. running GoHugo), essentially rendering the webpage to a static webpage. It will build and publish the static website to [gh-pages](https://github.com/airbytehq/glossary/tree/gh-pages) branch in the same repo.
+- [pages-build-deployment](https://github.com/airbytehq/glossary/actions/workflows/pages/pages-build-deployment) - this action configures hosting of [glossary.airbyte.com](https://glossary.airbyte.com) from static webpage assets which are stored in `gh-pages` branch.
 
-The `master` branch is also what you see on [glossary.airbyte.com](https://glossary.airbyte.com). So whenever you push changes to the `hugo` branch, it will automatically be merged and deployed.
+The `master` branch is what you see on [glossary.airbyte.com](https://glossary.airbyte.com). So whenever you push changes to the `master` branch, it will automatically be merged and deployed.
 
-The `hugo` branch is not protected and everyone can add. Maybe will change that later. For now, we want a fast update cycle.
+The `master` branch is not protected and everyone can add. Maybe will change that later. For now, we want a fast update cycle.
 


### PR DESCRIPTION
As per [#3640](https://app.zenhub.com/workspaces/production-engineering-632380080186f5001a13d1dd/issues/gh/airbytehq/airbyte-cloud/3640) now glossary assets will be deployed to`gh-pages` branch instead of intermediate repo `airbyteglossary/airbyteglossary.github.io `