### PR TITLE
Add GA4 tag to header

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -201,6 +201,16 @@
 <!-- bug: https://github.com/jackyzha0/quartz/issues/194
 {{ template "_internal/google_analytics.html" . }} 
 -->
+<!-- Google 4 tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-HDBMVFQGBH"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-HDBMVFQGBH');
+</script>
+
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-156258629-2"></script>
 <script>


### PR DESCRIPTION
Adds the GA4 tag to header, as a part of migration from Universal Analytics to GA4